### PR TITLE
Add ability to capture stderr

### DIFF
--- a/include/process.h
+++ b/include/process.h
@@ -290,7 +290,10 @@ class pipe_streambuf : public std::streambuf
         if (eback() == base)
         {
             // move the put_back area to the front
-            std::memmove(base, egptr() - put_back_size_, put_back_size_);
+            const auto dest = base;
+            const auto src  = egptr() - put_back_size_ < dest ? dest : egptr() - put_back_size_;
+            const auto area = egptr() - dest < put_back_size_ ? egptr() - dest : put_back_size_;
+            std::memmove(dest, src, area);
             start += put_back_size_;
         }
 


### PR DESCRIPTION
Adds the ability to capture a process's stderr pipe.. Since `std::streambuf` only has 1 read end and 1 write and, the stderr has to be backed by its own `streambuf`. Probably not be the best implementation, but it works.
