### PR TITLE
Add ability to capture stderr

### DIFF
--- a/include/process.h
+++ b/include/process.h
@@ -679,7 +679,7 @@ class process
     /**
      * Conversion to std::ostream.
      */
-    std::ostream& stdin()
+    std::ostream& input()
     {
         return in_stream_;
     }
@@ -687,7 +687,7 @@ class process
     /**
      * Conversion to std::istream.
      */
-    std::istream& stdout()
+    std::istream& output()
     {
         return out_stream_;
     }
@@ -695,7 +695,7 @@ class process
     /**
      * Conversion to std::istream.
      */
-    std::istream& stderr()
+    std::istream& error()
     {
         return err_stream_;
     }


### PR DESCRIPTION
Sorry, had to close PR #4 and move it here because that PR was accidentally created on my master branch which made it automatically update on new non-related commits. 

Anyway, this PR adds the ability to capture a process's stderr pipe.. Since std::streambuf only has 1 read end and 1 write and, the stderr has to be backed by its own streambuf. Probably not be the best implementation, but it works.
