### PR TITLE
More advanced version of process::running

### DIFF
--- a/cl_clang.sh
+++ b/cl_clang.sh
@@ -1,0 +1,1 @@
+clang++ -std=c++11 -Iinclude -Weverything -Wno-c++98-compat -Wno-padded -Wno-weak-vtables sample.cpp

--- a/cl_gcc.sh
+++ b/cl_gcc.sh
@@ -1,0 +1,2 @@
+g++ -std=c++11 -Iinclude -Wall -Wextra sample.cpp
+

--- a/include/process.h
+++ b/include/process.h
@@ -13,6 +13,7 @@
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <sys/wait.h>
+#include <signal.h>
 #include <unistd.h>
 #include <fcntl.h>
 

--- a/include/process.h
+++ b/include/process.h
@@ -644,12 +644,21 @@ class process
             pipe_buf_.close(pipe_t::write_end());
             err_buf_.close(pipe_t::write_end());
             waitpid(pid_, &status_, 0);
+            pid_ = -1;
             waited_ = true;
         }
     }
 
     /**
-     * Determines if process is running (zombies are seen as running).
+     * It wait() already called?
+     */
+    bool waited() const
+    {
+        return waited_;
+    }
+
+    /**
+     * Determines if process is running.
      */
     bool running() const
     {

--- a/include/process.h
+++ b/include/process.h
@@ -44,8 +44,8 @@ namespace procxx
 class pipe_t
 {
   public:
-    static constexpr int READ_END = 0;
-    static constexpr int WRITE_END = 1;
+    static constexpr unsigned int READ_END = 0;
+    static constexpr unsigned int WRITE_END = 1;
 
     /**
      * Wrapper type that ensures sanity when dealing with operations on
@@ -59,7 +59,7 @@ class pipe_t
          * the end passed makes sense (e.g., is either the READ_END or the
          * WRITE_END of the pipe).
          */
-        pipe_end(int end)
+        pipe_end(unsigned int end)
         {
             if (end != READ_END && end != WRITE_END)
                 throw exception{"invalid pipe end"};
@@ -69,13 +69,13 @@ class pipe_t
         /**
          * pipe_ends are implicitly convertible to ints.
          */
-        operator int() const
+        operator unsigned int() const
         {
             return end_;
         }
 
       private:
-        int end_;
+        unsigned int end_;
     };
 
     /**
@@ -153,7 +153,7 @@ class pipe_t
             throw exception{"failed to write"};
         }
         if (bytes < static_cast<ssize_t>(length))
-            write(buf + bytes, length - bytes);
+            write(buf + bytes, length - static_cast<uint64_t>(bytes));
     }
 
     /**
@@ -284,14 +284,15 @@ class pipe_ostreambuf : public std::streambuf
             // move the put_back area to the front
             const auto dest = base;
             const auto src  = egptr() - put_back_size_ < dest ? dest : egptr() - put_back_size_;
-            const auto area = static_cast<std::size_t>(egptr() - dest) < put_back_size_ ? egptr() - dest : put_back_size_;
+            const auto area = static_cast<std::size_t>(egptr() - dest) < put_back_size_ ?
+                static_cast<std::size_t>(egptr() - dest) : put_back_size_;
             std::memmove(dest, src, area);
             start += put_back_size_;
         }
 
         // start now points to the head of the usable area of the buffer
         auto bytes
-            = stdout_pipe_.read(start, in_buffer_.size() - (start - base));
+            = stdout_pipe_.read(start, in_buffer_.size() - static_cast<std::size_t>(start - base));
 
         if (bytes == -1)
         {
@@ -406,7 +407,7 @@ class pipe_streambuf : public pipe_ostreambuf
     {
         if (stdin_pipe_.open(pipe_t::write_end()))
         {
-            stdin_pipe_.write(pbase(), pptr() - pbase());
+            stdin_pipe_.write(pbase(), static_cast<std::size_t>(pptr() - pbase()));
             pbump(static_cast<int>(-(pptr() - pbase())));
         }
     }
@@ -414,6 +415,12 @@ class pipe_streambuf : public pipe_ostreambuf
     pipe_t stdin_pipe_;
     std::vector<char> out_buffer_;
 };
+
+class process;
+
+// Forward declaration. Will be defined later.
+bool running(pid_t pid);
+bool running(const process & pr);
 
 /**
  * A handle that represents a child process.
@@ -645,31 +652,7 @@ class process
      */
     bool running() const
     {
-        bool result = false;
-        if (pid_ != -1)
-        {
-            if (0 == ::kill(pid_, 0))
-            {
-                int status;
-                const auto r = ::waitpid(pid_, &status, WNOHANG);
-                if (-1 == r)
-                {
-                    perror("waitpid()");
-                    throw exception{"Failed to check process state "
-                        "by waitpid(): "
-                        + std::system_category().message(errno)};
-                }
-                if (r == pid_)
-                    // Process has changed its state. We must detect why.
-                    result = !WIFEXITED(status) && !WIFSIGNALED(status);
-                else
-                    // No changes in the process status. It means that
-                    // process is running.
-                    result = true;
-            }
-        }
-
-        return result;
+        return ::procxx::running(*this);
     }
 
     /**
@@ -899,5 +882,47 @@ inline pipeline operator|(process& first, process& second)
     pipeline p{first};
     return p | second;
 }
+
+/**
+ * Determines if process is running (zombies are seen as running).
+ */
+inline bool running(pid_t pid)
+{
+    bool result = false;
+    if (pid != -1)
+    {
+        if (0 == ::kill(pid, 0))
+        {
+            int status;
+            const auto r = ::waitpid(pid, &status, WNOHANG);
+            if (-1 == r)
+            {
+                perror("waitpid()");
+                throw process::exception{"Failed to check process state "
+                    "by waitpid(): "
+                    + std::system_category().message(errno)};
+            }
+            if (r == pid)
+                // Process has changed its state. We must detect why.
+                result = !WIFEXITED(status) && !WIFSIGNALED(status);
+            else
+                // No changes in the process status. It means that
+                // process is running.
+                result = true;
+        }
+    }
+
+    return result;
 }
+
+/**
+ * Determines if process is running (zombies are seen as running).
+ */
+inline bool running(const process & pr)
+{
+    return running(pr.id());
+}
+
+}
+
 #endif

--- a/sample.cpp
+++ b/sample.cpp
@@ -1,0 +1,26 @@
+#include <process.h>
+
+#include <iostream>
+
+int main()
+{
+    procxx::process ping( "ping", "www.google.com", "-c", "2" );
+    ping.exec();
+
+    std::string line;
+    while( std::getline( ping.output(), line ) )
+    {
+        std::cout << line << std::endl;
+        if( !ping.running() || !procxx::running(ping.id()) || !running(ping) )
+        {
+            std::cout << "not running any more" << std::endl;
+            break;
+        }
+    }
+
+    ping.wait();
+    std::cout << "exit code: " << ping.code() << std::endl;
+
+    return 0;
+}
+


### PR DESCRIPTION
I added handing of result of ::pipe2 call (there is a warning from gcc when high warning level is on).

I changed logic of process::running to detect zombies (by calling waitpid with WNOHANG and processing its result).

UPD. There is also two free functions procxx::running() which do the same thing as process::running(). I have found that this functionality could be useful if there is only pid of child process.
