### PR TITLE
Modify constructor to enable const std::string& as a first argument

### DIFF
--- a/include/process.h
+++ b/include/process.h
@@ -434,7 +434,7 @@ class process
      * passing the given arguments to it.
      */
     template <class... Args>
-    process(std::string&& application, Args&&... args)
+    process(std::string application, Args&&... args)
         : args_{std::move(application), std::forward<Args>(args)...},
           in_stream_{&pipe_buf_},
           out_stream_{&pipe_buf_},


### PR DESCRIPTION
Modify constructor signature to be able to use it passing `const std::string &` as a first argument.
